### PR TITLE
Create a Service Catalog portfolio for S3-related products

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "submodules/s3-logging"]
+	path = submodules/s3-logging
+	url = https://github.com/ShahradR/s3-logging.git
+	branch = main

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -1,0 +1,14 @@
+---
+project:
+  name: sc-s3-product
+  regions:
+    - ca-central-1
+  s3_bucket: brokentech-cfn
+
+tests:
+  s3-portfolio-with-default-parameters:
+    template: ./templates/s3-portfolio.yaml
+    parameters:
+      PortfolioName: S3 buckets
+      PortfolioDescription: S3 buckets
+      TemplateUrlPrefix: https://$[taskcat_autobucket].s3.ca-central-1.amazonaws.com/sc-s3-product/

--- a/templates/s3-portfolio.yaml
+++ b/templates/s3-portfolio.yaml
@@ -1,0 +1,77 @@
+---
+Description: |
+  Porfolio containing all S3-related products, along with the necessary roles
+  and configurations to allow end-users to provision resources.
+
+Parameters:
+  PortfolioName:
+    Type: String
+    Description: Name for the Service Catalog portfolio.
+  PortfolioProvider:
+    Type: String
+    Description: |
+      (Optional) Name of the portfolio's provider. The provieder appears in the
+      UI when users list available portfolios. Defaults to "BrokenTech."
+    Default: BrokenTech
+  PortfolioDescription:
+    Type: String
+    Description: |
+      (Optional) Description for the portfolio. The description appears in the
+      UI when users list available portfolios. Defaults to the description in
+      the template.
+    Default: |
+      Portfolio containing a collection of AWS Simple Storage Service (S3)
+      products.
+  TemplateUrlPrefix:
+    Type: String
+    Description: |
+      Address for the S3 bucket where the CloudFormation templates are
+      deployed. Should be passed in the format below, where [bucket] is the
+      name of your S3 bucket. Note the tailing "/" at the end of the address.
+
+      https://[bucket].s3.ca-central-1.amazonaws.com/sc-s3-product/
+
+Resources:
+  S3Portfolio:
+    Type: AWS::ServiceCatalog::Portfolio
+    Properties:
+      ProviderName:
+        Ref: PortfolioProvider
+      Description:
+        Ref: PortfolioDescription
+      DisplayName:
+        Ref: PortfolioName
+
+  S3ServerLoggingProduct:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Parameters:
+        TemplateUrlPrefix:
+          Fn::Sub: "${TemplateUrlPrefix}submodules/s3-logging/"
+      TemplateURL:
+        Fn::Sub: "${TemplateUrlPrefix}submodules/s3-logging/templates/s3-logging-product.yaml"
+      TimeoutInMinutes: 5
+
+  S3PortfolioLaunchRole:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL:
+        Fn::Sub: "${TemplateUrlPrefix}templates/sc-s3-launchrole.yaml"
+
+  S3ServerLoggingPortfolioAssociation:
+    Type: "AWS::ServiceCatalog::PortfolioProductAssociation"
+    Properties:
+      PortfolioId:
+        Ref: S3Portfolio
+      ProductId:
+        Fn::GetAtt: [S3ServerLoggingProduct, Outputs.ProductId]
+
+  LaunchRoleConstraint:
+    Type: AWS::ServiceCatalog::LaunchRoleConstraint
+    Properties:
+      PortfolioId:
+        Ref: S3Portfolio
+      ProductId:
+        Fn::GetAtt: [S3ServerLoggingProduct, Outputs.ProductId]
+      RoleArn:
+        Fn::GetAtt: [S3PortfolioLaunchRole, Outputs.LaunchRoleArn]

--- a/templates/sc-s3-launchrole.yaml
+++ b/templates/sc-s3-launchrole.yaml
@@ -64,6 +64,12 @@ Resources:
                   - "cloudformation:ValidateTemplate"
                   - "cloudformation:UpdateStack"
                 Resource: "*"
+              - Sid: S3BucketSecretSID
+                Effect: Allow
+                Action:
+                  - ssm:GetParameters
+                Resource:
+                  Fn::Sub: "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/s3-logging-iam-role"
 Outputs:
   LaunchRoleArn:
     Value:

--- a/templates/sc-s3-launchrole.yaml
+++ b/templates/sc-s3-launchrole.yaml
@@ -1,0 +1,73 @@
+# Copyright 2018-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Description: "ServiceCatalog S3 Launch Role. (fdp-1p5s1035s)"
+Resources:
+  SCS3LaunchRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      RoleName: SCS3LaunchRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - servicecatalog.amazonaws.com
+            Action:
+              - "sts:AssumeRole"
+      Path: /
+      Policies:
+        - PolicyName: SCLaunchPolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Sid: SCLaunchPolicySID
+                Effect: Allow
+                Action:
+                  - "servicecatalog:ListServiceActionsForProvisioningArtifact"
+                  - "servicecatalog:ExecuteprovisionedProductServiceAction"
+                  - "iam:ListRolePolicies"
+                  - "iam:ListPolicies"
+                  - "iam:DeleteRole"
+                  - "iam:GetRole"
+                  - "iam:PassRole"
+                  - "iam:ListRoles"
+                  - "iam:CreateRole"
+                  - "iam:DetachRolePolicy"
+                  - "iam:AttachRolePolicy"
+                  - "cloudformation:DescribeStackResource"
+                  - "cloudformation:DescribeStackResources"
+                  - "cloudformation:GetTemplate"
+                  - "cloudformation:List*"
+                  - "cloudformation:DescribeStackEvents"
+                  - "cloudformation:DescribeStacks"
+                  - "cloudformation:CreateStack"
+                  - "cloudformation:DeleteStack"
+                  - "cloudformation:DescribeStackEvents"
+                  - "cloudformation:DescribeStacks"
+                  - "cloudformation:GetTemplateSummary"
+                  - "cloudformation:SetStackPolicy"
+                  - "cloudformation:ValidateTemplate"
+                  - "cloudformation:UpdateStack"
+                Resource: "*"
+Outputs:
+  LaunchRoleArn:
+    Value:
+      Fn::GetAtt: SCS3LaunchRole.Arn
+  LaunchRoleName:
+    Value:
+      Ref: SCS3LaunchRole


### PR DESCRIPTION
Create a Service Catalog portfolio containing S3-related products. This allows end-users to quickly and easily provision new AWS resources from a pre-approved catalog of products.

The CloudFormation templates are inspired by the following two sources:
- The [aws-samples/aws-service-catalog-reference-architectures](https://github.com/aws-samples/aws-service-catalog-reference-architectures) repository
- The [_Creating a secure DevOps pipeline for AWS Service Catalog_ on the AWS Management & Governance Blog](https://aws.amazon.com/blogs/mt/creating-a-secure-devops-pipeline-for-aws-service-catalog/).

The [`sc-s3-launchrole.yaml`](https://github.com/ShahradR/sc-s3-portfolio/blob/b1c3ed6fd918d2d2db21e50847b2eafb4e66e435/templates/sc-s3-launchrole.yaml) template itself was taken from the aws-service-catalog-reference-architectures.

Closes ShahradR/sc-s3-portfolio#1

# Post-certification
## Admin experience
### Portfolio
As an administrator, navigate to the AWS Service Catalog Management Console, and open the **Portfolios** page. The **S3 buckets** portfolio should appear in the list.

![image](https://user-images.githubusercontent.com/5815058/90964232-94218300-e48c-11ea-88fb-168cababe2fa.png)

In the portfolio, the **Amazon S3 logging bucket** product should be listed.

![image](https://user-images.githubusercontent.com/5815058/90964597-fe87f280-e48f-11ea-9e55-2240c9a79850.png)

### Product list
As an administrator, navigate to the AWS Service Catalog Management Console, and open the "Products" page. The **Amazon S3 logging bucket** product should appear in the list.

![image](https://user-images.githubusercontent.com/5815058/90964142-ef9f4100-e48b-11ea-852f-72824635cba3.png)

## End user experience
Before running the end user tests, make sure a user, role, or group representing the end user has been added to the portfolio.

![image](https://user-images.githubusercontent.com/5815058/90964780-8fab9900-e491-11ea-9c0f-480425d61431.png)

As an end-user, navigate to the AWS Service Catalog Management Console, and provision the new service catalog product.

![end-user-sc-provision-product](https://user-images.githubusercontent.com/5815058/90965657-35fa9d00-e498-11ea-8f80-2e345cd56511.gif)
